### PR TITLE
Fix compilation problem with newest asterisk versions

### DIFF
--- a/res_json.c
+++ b/res_json.c
@@ -11,7 +11,7 @@
  * the project provides a web site, mailing lists and IRC
  * channels for your use.
  *
- * This program is free software, distributed under the terms of
+ * This program is ast_free software, distributed under the terms of
  * the GNU General Public License Version 2. See the LICENSE file
  * at the top of the source tree.
  *
@@ -41,7 +41,7 @@
 
 #include "asterisk.h"
 
-ASTERISK_FILE_VERSION(__FILE__, "$Revision: 200656 $")
+
 
 #include "asterisk/file.h"
 #include "asterisk/channel.h"
@@ -282,7 +282,7 @@ static int jsonpretty_exec(struct ast_channel *chan,
 	char *pretty = cJSON_Print(doc);
 	ast_copy_string(buffer, pretty, buflen);
 	cJSON_Delete(doc);
-	free(pretty);
+	ast_free(pretty);
 	json_set_operation_result(chan, ASTJSON_OK);
 	return 0;
 
@@ -320,7 +320,7 @@ static int jsoncompress_exec(struct ast_channel *chan,
 	char *unpretty = cJSON_PrintUnformatted(doc);
 	ast_copy_string(buffer, unpretty, buflen);
 	cJSON_Delete(doc);
-	free(unpretty);
+	ast_free(unpretty);
 	json_set_operation_result(chan, ASTJSON_OK);
 	return 0;
 
@@ -398,7 +398,7 @@ static int jsonelement_exec(struct ast_channel *chan,
 			else
 				ast_asprintf(&value, "%d", thisobject->valueint); 
 			ast_copy_string(buffer, value, buflen); 
-			free(value);
+			ast_free(value);
 			break;
 		case cJSON_String: 
 			type = ast_strdupa("string"); 
@@ -473,14 +473,14 @@ static int jsonvariables_exec(struct ast_channel *chan, const char *data) {
 					else
 						ast_asprintf(&num, "%d", nvp->valueint); 
 					pbx_builtin_setvar_helper(chan, nvp->string, num); 
-					free(num);
+					ast_free(num);
 					break;
 				case cJSON_String: pbx_builtin_setvar_helper(chan, nvp->string, nvp->valuestring); break;
 				case cJSON_Array: pbx_builtin_setvar_helper(chan, nvp->string, "!array!"); break;
 				case cJSON_Object: 
 					eljson = cJSON_PrintUnformatted(nvp);
 					pbx_builtin_setvar_helper(chan, nvp->string, eljson); 
-					free(eljson);
+					ast_free(eljson);
 					break;
 				default: 
 					break;
@@ -639,7 +639,7 @@ static int jsonadd_exec(struct ast_channel *chan, const char *data) {
 		pbx_builtin_setvar_helper(chan, args.json, jsonresult);
 	// cleanup the mess and let's get outta here
 	ast_log(LOG_DEBUG, "resulting json: %s\n", jsonresult);
-	free(jsonresult);
+	ast_free(jsonresult);
 	cJSON_Delete(doc);
 	json_set_operation_result(chan, ret);
 	return 0;
@@ -764,7 +764,7 @@ static int jsonset_exec(struct ast_channel *chan, const char *data) {
 	if (ret == ASTJSON_OK)
 		pbx_builtin_setvar_helper(chan, args.json, jsonresult);
 	// cleanup the mess and let's get outta here
-	free(jsonresult);
+	ast_free(jsonresult);
 	cJSON_Delete(doc);
 	json_set_operation_result(chan, ret);
 	return 0;
@@ -857,7 +857,7 @@ static int jsondelete_exec(struct ast_channel *chan, const char *data) {
 	char *jsonresult = cJSON_PrintUnformatted(doc);
 	if (ret == ASTJSON_OK)
 		pbx_builtin_setvar_helper(chan, args.jsonvarname, jsonresult); 
-	free(jsonresult);
+	ast_free(jsonresult);
 	cJSON_Delete(doc);
 	json_set_operation_result(chan, ret);
 	return 0;


### PR DESCRIPTION
I try to compile the module on Asterisk version 16.7.0 and the same compilation error referenced here https://github.com/drivefast/asterisk-res_json/issues/9 occour. According asterisk documentation, the line "ASTERISK_FILE_VERSION(__FILE__, "$Revision: 200656 $")" is not necesssary anymore, so you have to remove that from res_json.c. Another modification is in "free" function, that have to be ast_free as used on another modules like chan_sip.c. This is the two necessary modifications to compile this module on newest versions of asterisk. An pull request was send with this changes.

Notes on  **asterisk-16.7.0/ChangeLog** : 

![change_log_1](https://user-images.githubusercontent.com/50053924/118994494-c5b47580-b95c-11eb-9c56-a807961cf7c0.png)

![change_log_2](https://user-images.githubusercontent.com/50053924/118994523-cb11c000-b95c-11eb-8fe5-dd185c8162d1.png)

