### PR TITLE
jsonvariables option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ what'd you get
 a bunch of apps and functions:
 
 - `JSONELEMENT(doc,path)` (r/o function) - gets the value of an element at a given path in a json document
-- `jsonvariables(doc)` (app) - reads a single level json document (dictionary) into dialplan variables
+- `jsonvariables(doc,varprefix)` (app) - reads a single level json document (dictionary) into dialplan variables
 - `jsonadd(doc,path,elemtype,name,value)` (app) - adds an element to the json document at the given path
 - `jsonset(doc,path,newvalue)` (app) - changes the value of an element in the json document
 - `jsondelete(doc,path)` (app) - deletes an element in the json document


### PR DESCRIPTION
To avoid variables replace in dialplan, this patch allows to set the variables prefix to jsonvariables. 

Works on Asterisk 16 and 18.

dialplan example:

exten => s,1,noop(teste-curl)
 same => n,set(CURLOPT(useragent)=White Label PBX)
 same => n,set(json=${CURL(http://localhost/test.curl.html)})
 same => n,jsonvariables(json,myjson)
 same => n,dumpchan()

running log:

Connected to Asterisk 16.16.1~dfsg-1 currently running on vinicius-Inspiron-5566 (pid = 1298817)
    -- Executing [111@dialplan-7648690510:1] Set("PJSIP/7648690510-00000007", "__DIALED_NUMBER=111") in new stack
    -- Executing [111@dialplan-7648690510:2] Gosub("PJSIP/7648690510-00000007", "test-curl,s,1") in new stack
    -- Executing [s@teste-curl:1] NoOp("PJSIP/7648690510-00000007", "test-curl") in new stack
    -- Executing [s@teste-curl:2] Set("PJSIP/7648690510-00000007", "CURLOPT(useragent)=White Label PBX") in new stack
    -- Executing [s@teste-curl:3] Set("PJSIP/7648690510-00000007", "json={"code":"0","message":"sucesso"}") in new stack
    -- Executing [s@teste-curl:4] jsonvariables("PJSIP/7648690510-00000007", "json,myjson") in new stack
[Dec 15 14:32:52] NOTICE[1309722][C-00000008]: res_json.c:465 jsonvariables_exec: varprefix is set to 'myjson'
[Dec 15 14:32:52] NOTICE[1309722][C-00000008]: res_json.c:481 jsonvariables_exec: setting var 'myjson_code'
[Dec 15 14:32:52] NOTICE[1309722][C-00000008]: res_json.c:481 jsonvariables_exec: setting var 'myjson_message'
    -- Executing [s@teste-curl:5] DumpChan("PJSIP/7648690510-00000007", "") in new stack

Variables:
JSONRESULT=0
myjson_message=sucesso
myjson_code=0
json={"code":"0","message":"sucesso"}
ARGC=0
DIALED_NUMBER=111
SIPDOMAIN=192.168.15.116
